### PR TITLE
Completely document public interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,18 @@ edition = "2018"
 description = "A library to communicate with paypal api"
 license = "MIT"
 repository = "https://github.com/nikosEfthias/paypal"
+
 [dependencies]
-reqwest = "0.9.5"
-serde = "1.0.83"
-serde_derive = "1.0.83"
-serde_json = "1.0.33"
-base64 = "0.10.0"
+reqwest = "0.9.18"
+serde = { version = "1.0.99", features = ["derive"] }
+serde_json = "1.0.40"
+base64 = "0.10.1"
+chrono = { version = "*", features = ["serde"] }
+
+[dev-dependencies]
+dotenv = "*"
+lazy_static = "*"
+
+[features]
+default = []
+test-mode = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+/// Denotes the way creating a payment can fail.
+#[derive(Debug, Deserialize)]
+pub struct Error {
+    /// A error message with information about why the request failed
+    message: String,
+    /// If the cause of the error is a bad http reponse, this is the status code
+    status: Option<u16>,
+    /// If the cause of the error is a bad http reponse, this is the remote url
+    /// (either starting with https://api.sandbox.paypal.com or https://api.paypal.com/v1)
+    remote: Option<String>,
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Self {
+            message: err.to_string(),
+            status: err.status().map(|status| status.as_u16()),
+            remote: err.url().map(|url| url.to_string()),
+        }
+    }
+}
+
+impl From<reqwest::Response> for Error {
+    fn from(mut response: reqwest::Response) -> Self {
+        Self {
+            message: response.text().unwrap(),
+            status: Some(response.status().as_u16()),
+            remote: Some(response.url().to_string()),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,47 @@
+#![deny(missing_docs)]
+
+//! A crate that serves to abstract away the network aspect of interfacing with paypal.
+//! Created by nikos
+//!
+//! Creating a payment is done using the `create_payment` function.
+//! ```rust,no_run
+//! let token = paypal::get_token("my_id", "my_secret")?;
+//! let amount = TransactionAmount {
+//!     currency: "USD".to_string(),
+//!     total: "100.00".to_string()
+//! };
+//! let new_payment = payment::new(
+//!     &token.access_token,
+//!     "mysite.com/whooyoupaid",
+//!     "mysite.com/nooyoufailed",
+//!     PaymentMethod::Paypal,
+//!     PaymentIntent::Sale,
+//!     vec![Transaction { amount }],
+//! )?;
+//! ```
+
+/// Possible ways that a paypal request can fail
+pub mod error;
+mod payment;
 mod request;
 mod token;
-pub mod types;
-pub mod payment;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-pub use self::token::get_token;
+
+mod types;
+
+pub use token::get_token;
+pub use types::{
+    Address, ApplicationContext, CreditCard, CreditCardToken, FailureReason, FundingInstrument,
+    LinkDescription, ListPaymentResponse, NormalizationStatus, Payer, PayerStatus, Payment,
+    PaymentIntent, PaymentMethod, RedirectUrls, State, Transaction, TransactionAmount,
+};
+pub use payment::*;
+
+#[cfg(feature = "test-mode")]
 const _ADDR: &str = "https://api.sandbox.paypal.com/v1";
-fn _make_endpoint(ep: &str) -> String //{{{
-{
-    let mut _ep = String::from(_ADDR);
-    _ep.push_str(ep);
-    _ep
-} //}}}
+
+#[cfg(not(feature = "test-mode"))]
+const _ADDR: &str = "https://api.paypal.com/v1";
+
+fn _make_endpoint(ep: &str) -> String {
+    format!("{}{}", _ADDR, ep)
+}

--- a/src/payment.rs
+++ b/src/payment.rs
@@ -44,6 +44,8 @@ pub fn new(
         },
         payer: Payer {
             payment_method: method,
+            funding_instruments: None,
+            status: None,
         },
         intent,
         transactions,

--- a/src/payment.rs
+++ b/src/payment.rs
@@ -1,17 +1,31 @@
-use super::request::Resp;
-use super::types::{
-    //{{{
-    Payer,
-    PaymentIntent,
-    PaymentMethod,
-    RedirectUrls,
-    RequestNewPayment,
+use crate::request::Resp;
+use crate::types::Payment;
+use crate::types::{
+    ListPaymentResponse, Payer, PaymentIntent, PaymentMethod, RedirectUrls, RequestNewPayment,
     Transaction,
-    TransactionAmount,
-    //}}}
 };
 use std::collections::HashMap;
-// fn new{{{
+
+/// Use this endpoint to create a new payment.
+/// You can obtain a new bearer token using the `get_token` function provided.
+/// ```rust,no_run
+/// use paypal::{get_token, payment};
+/// use paypal::{PaymentMethod, PaymentIntent, Transaction, TransactionAmount};
+///
+/// let token = get_token("my_id", "my_secret").unwrap();
+/// let amount = TransactionAmount {
+///     currency: "USD".to_string(),
+///     total: "100.00".to_string()
+/// };
+/// let new_payment = payment::new(
+///     &token.access_token,
+///     "mysite.com/whooyoupaid",
+///     "mysite.com/nooyoufailed",
+///     PaymentMethod::Paypal,
+///     PaymentIntent::Sale,
+///     vec![Transaction { amount }],
+/// ).unwrap();
+/// ```
 pub fn new(
     bearer: &str,
     return_url: &str,
@@ -19,11 +33,10 @@ pub fn new(
     method: PaymentMethod,
     intent: PaymentIntent,
     transactions: Vec<Transaction>,
-) -> Result<super::request::ResponseData, String>
-{
-    let ep = super::_make_endpoint("/payments/payment");
+) -> Resp<Payment> {
+    let ep = crate::_make_endpoint("/payments/payment");
     let mut headers = HashMap::new();
-    headers.insert("Authorization".into(), format!("Bearer {}", bearer).into());
+    headers.insert("Authorization".into(), format!("Bearer {}", bearer));
     let body = RequestNewPayment {
         redirect_urls: RedirectUrls {
             return_url: return_url.into(),
@@ -32,32 +45,102 @@ pub fn new(
         payer: Payer {
             payment_method: method,
         },
-        intent: intent,
-        transactions: transactions,
+        intent,
+        transactions,
     };
-    super::request::post_json(ep.as_str(), &mut headers, &body)
-} //}}}
-  //{{{ fn list
-pub fn list(bearer: &str) -> Resp
-{
+    crate::request::post_json(ep.as_str(), &mut headers, &body)
+}
+
+/// Returns a list of all transactions made using the account that corresponds to the
+/// provided bearer token.
+///
+/// ```rust,no_run
+/// let token = get_token("my_id", "my_secret").unwrap();
+/// let list = payment::list(&token).unwrap();
+/// ```
+pub fn list(bearer: &str) -> Resp<ListPaymentResponse> {
     let mut headers = HashMap::new();
-    headers.insert("Authorization".into(), format!("Bearer {}", bearer).into());
-    super::request::get(
-        super::_make_endpoint("/payments/payment").as_str(),
+    headers.insert("Authorization".into(), format!("Bearer {}", bearer));
+    crate::request::get(
+        crate::_make_endpoint("/payments/payment").as_str(),
         &headers,
     )
-} //}}}
-  //{{{ fn execute
-pub fn execute(bearer: &str, payment_id: &str, payer_id: &str) -> Resp
-{
+}
+
+/// Finalizes charging of a previously constructed payment. This usually comes after the payment
+/// has been created and _approved_ by the customer.
+///
+/// ```rust,no_run
+/// use paypal::{get_token, payment};
+/// use paypal::{PaymentMethod, PaymentIntent, Transaction, TransactionAmount};
+///
+/// let token = get_token("my_id", "my_secret").unwrap();
+/// let amount = TransactionAmount {
+///     currency: "USD".to_string(),
+///     total: "100.00".to_string()
+/// };
+/// let new_payment = payment::new(
+///     &token.access_token,
+///     "mysite.com/whooyoupaid",
+///     "mysite.com/nooyoufailed",
+///     PaymentMethod::Paypal,
+///     PaymentIntent::Sale,
+///     vec![Transaction { amount }],
+/// ).unwrap();
+/// // Have the user approve the payment here, using the webpage in payment.links, for example:
+/// let payer_id = function_that_sends_user_to_webpage(&new_payment);
+/// let finalized_payment = payment::execute(&token, &new_payment.id, &payer_id).unwrap();
+/// ```
+pub fn execute(bearer: &str, payment_id: &str, payer_id: &str) -> Resp<Payment> {
     let mut headers = HashMap::new();
     let mut body = headers.clone();
-    headers.insert("Authorization".into(), format!("Bearer {}", bearer).into());
+    headers.insert("Authorization".into(), format!("Bearer {}", bearer));
     body.insert("payer_id".into(), payer_id.into());
-    super::request::post_json(
-        super::_make_endpoint(format!("/payments/payment/{}/execute", payment_id).as_str())
-            .as_str(),
+    crate::request::post_json(
+        &crate::_make_endpoint(&format!("/payments/payment/{}/execute", payment_id)).as_str(),
         &mut headers,
         &body,
     )
-} //}}}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lazy_static::lazy_static;
+    use std::io::{self, BufRead};
+
+    lazy_static! {
+        static ref CLIENT_ID: String = {
+            dotenv::dotenv().ok();
+            std::env::var("CLIENT_ID").expect("`CLIENT_ID` env parameter to be set")
+        };
+        static ref SECRET: String = {
+            dotenv::dotenv().ok();
+            std::env::var("SECRET").expect("`SECRET` env parameter to be set")
+        };
+    }
+
+    #[test]
+    fn test_new() {
+        let token = crate::get_token(&CLIENT_ID, &SECRET).unwrap(); // alos checked by other test
+        let amount = crate::types::TransactionAmount {
+            currency: "USD".to_string(),
+            total: "100.00".to_string(),
+        };
+        new(
+            &token.access_token,
+            "mysite.com/whooyoupaid",
+            "mysite.com/nooyoufailed",
+            PaymentMethod::Paypal,
+            PaymentIntent::Sale,
+            vec![Transaction { amount }],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_list() {
+        let token = crate::get_token(&CLIENT_ID, &SECRET).unwrap();
+        let _list = list(&token.access_token).unwrap();
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,92 +1,64 @@
-use reqwest::{
-    header::HeaderMap,
-    Client,
-    Response,
-};
+use crate::error::Error;
+use reqwest::{header::HeaderMap, Client, Response};
 use std::collections::HashMap;
-use std::error::Error;
 use std::str::FromStr;
-pub type Resp = Result<ResponseData,String>;
-#[derive(Debug)]
-pub struct ResponseData
-{
-    pub status: String,
-    pub headers: Vec<(String, String)>,
-    pub body: String,
-}
-impl ResponseData //{{{
-{
-    pub fn status_code(&self) -> i64
-    {
-        self.status
-            .split_whitespace()
-            .next()
-            .unwrap()
-            .parse()
-            .unwrap()
-    }
-} //}}}
-pub fn post(
+
+pub type Resp<T> = Result<T, Error>;
+
+pub fn post<T>(
     url: &str,
     headers: &HashMap<String, String>,
     form: &HashMap<String, String>,
-) -> Resp
+) -> Resp<T>
+where
+    T: serde::de::DeserializeOwned,
 {
     let client = Client::new();
     let client = client.post(url);
-    let resp = client.headers(*_build_headers(headers)).form(form).send();
-    _build_response(resp)
-}
-pub fn get(url: &str, headers: &HashMap<String, String>) -> Resp
-{
-    let client = Client::new();
-    let client = client.get(url);
-    let resp = client.headers(*_build_headers(headers)).send();
+    let resp = client.headers(_build_headers(headers)).form(form).send();
     _build_response(resp)
 }
 
-pub fn post_json<T>(
-    url: &str,
-    headers: &mut HashMap<String, String>,
-    form: &T,
-) -> Resp
+pub fn get<T>(url: &str, headers: &HashMap<String, String>) -> Resp<T>
 where
-    T: serde::Serialize + ?Sized,
+    T: serde::de::DeserializeOwned,
+{
+    let client = Client::new();
+    let client = client.get(url);
+    let resp = client.headers(_build_headers(headers)).send();
+    _build_response(resp)
+}
+
+pub fn post_json<F, T>(url: &str, headers: &mut HashMap<String, String>, form: &F) -> Resp<T>
+where
+    F: serde::Serialize + ?Sized,
+    T: serde::de::DeserializeOwned,
 {
     let client = Client::new();
     let client = client.post(url);
     headers.insert("Content-Type".into(), "application/json".into());
-    let resp = client.headers(*_build_headers(headers)).json(form).send();
+    let resp = client.headers(_build_headers(headers)).json(form).send();
     _build_response(resp)
 }
 
-fn _build_headers<'a>(map: &'a HashMap<String, String>) -> Box<HeaderMap> //{{{
-{
-    let mut header_map = Box::new(HeaderMap::new());
-    (*map).iter().for_each(|(k, v)| {
-        (*header_map).insert(
+fn _build_headers(map: &HashMap<String, String>) -> HeaderMap {
+    let mut header_map = HeaderMap::new();
+    map.iter().for_each(|(k, v)| {
+        header_map.insert(
             reqwest::header::HeaderName::from_str(k.as_str()).unwrap(),
             v.parse().unwrap(),
         );
     });
     header_map
-} //}}}
-fn _build_response(r: reqwest::Result<Response>) -> Resp //{{{
+}
+
+fn _build_response<T>(mut r: reqwest::Result<Response>) -> Resp<T>
+where
+    T: serde::de::DeserializeOwned,
 {
-    if let Ok(mut r) = r
-    {
-        let mut _headers = vec![];
-        r.headers()
-            .iter()
-            .for_each(|(k, v)| _headers.push((k.to_string(), v.to_str().unwrap().to_string())));
-        Ok(ResponseData {
-            status: r.status().to_string(),
-            headers: _headers,
-            body: r.text().unwrap(),
-        })
+    match r {
+        Ok(ref mut r) if r.status().is_success() => Ok(r.json().unwrap()),
+        Ok(r) => Err(r.into()),
+        Err(err) => Err(err.into()),
     }
-    else
-    {
-        Err(r.unwrap_err().description().to_string())
-    }
-} //}}}
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,11 @@
+use crate::error::Error;
+use crate::types::ResponseAccessToken;
 use base64::encode;
-pub fn get_token(id: &str, secret: &str) -> Result<super::types::ResponseAccessToken, String> //{{{
-{
-    let ep = super::_make_endpoint("/oauth2/token");
+
+/// This function uses your `client id` and `secret`, and creates a bearer token that
+/// you must use to get access to the paypal endpoints
+pub fn get_token(id: &str, secret: &str) -> Result<ResponseAccessToken, Error> {
+    let ep = crate::_make_endpoint("/oauth2/token");
     let auth_header = prepare_auth_header(id, secret);
     let mut headers = std::collections::HashMap::<String, String>::new();
     headers.insert("Authorization".into(), auth_header);
@@ -11,41 +15,54 @@ pub fn get_token(id: &str, secret: &str) -> Result<super::types::ResponseAccessT
     );
     let mut form = std::collections::HashMap::new();
     form.insert("grant_type".into(), "client_credentials".into());
-    match super::request::post(&ep, &headers, &form)
-    {
-        Ok(resp) => Ok(serde_json::from_str(&resp.body[..]).unwrap()),
-        Err(err) => Err(err),
-    }
-} //}}}
-fn prepare_auth_header(id: &str, secret: &str) -> String //{{{
-{
+    crate::request::post(&ep, &headers, &form)
+}
+
+fn prepare_auth_header(id: &str, secret: &str) -> String {
     format!("Basic {}", base64_credentials(id, secret))
-} //}}}
-fn base64_credentials(id: &str, secret: &str) -> String //{{{
-{
+}
+
+fn base64_credentials(id: &str, secret: &str) -> String {
     let mut key = String::from(id);
     key.push_str(":");
     key.push_str(secret);
     encode(&key)
-} //}}}
-#[cfg(test)] //{{{
-mod tests
-{
+}
+
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[test] // base64 credentials {{{
-    fn test_base64_credentials()
-    {
+    use lazy_static::lazy_static;
+
+    lazy_static! {
+        static ref CLIENT_ID: String = {
+            dotenv::dotenv().ok();
+            std::env::var("CLIENT_ID").expect("`CLIENT_ID` env parameter to be set")
+        };
+        static ref SECRET: String = {
+            dotenv::dotenv().ok();
+            std::env::var("SECRET").expect("`SECRET` env parameter to be set")
+        };
+    }
+
+    #[test]
+    fn test_base64_credentials() {
         assert_eq!(
             "bmlrb3M6cGFzc3dvcmQ=",
             base64_credentials("nikos", "password")
         )
-    } //}}}
-    #[test] // prepare_auth_header {{{
-    fn test_prepare_auth_header()
-    {
+    }
+
+    #[test]
+    fn test_prepare_auth_header() {
         assert_eq!(
             "Basic bmlrb3M6cGFzc3dvcmQ=",
             prepare_auth_header("nikos", "password")
         )
-    } //}}}
-} //}}}
+    }
+
+    #[test]
+    fn test_get_token() {
+        get_token(&CLIENT_ID, &SECRET).unwrap();
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ use chrono as chr;
 use serde::{Deserialize, Serialize};
 
 // paypals reply when requesting a new jwt
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ResponseAccessToken {
     scope: String,
     pub nonce: String,
@@ -21,7 +21,7 @@ pub struct RequestNewPayment {
 }
 
 /// A single payment in PayPal's system, either completed or not.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Payment {
     /// The ID of the payment.
     pub id: String,
@@ -57,7 +57,7 @@ pub struct Payment {
 }
 
 /// Used to customize the payment flow page.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ApplicationContext {
     /// A label that overrides the business name in the merchant's PayPal account on the PayPal
     /// checkout pages.
@@ -78,7 +78,7 @@ pub struct ApplicationContext {
 }
 
 /// The shipping preference.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ShippingPreference {
     /// Redacts the shipping address from the PayPal pages. Recommended for digital goods.
@@ -92,7 +92,7 @@ pub enum ShippingPreference {
 }
 
 /// A struct containing a url and some metadata.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct LinkDescription {
     /// The complete target URL. To make the related call, combine the method with this URI
     /// Template-formatted link. For pre-processing, include the `$`, `(`, and `)` characters. The
@@ -107,7 +107,7 @@ pub struct LinkDescription {
 }
 
 /// Returned when listing all payments in the system.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ListPaymentResponse {
     /// A vector of the payments
     pub payments: Vec<Payment>,
@@ -201,7 +201,7 @@ pub enum PaymentMethod {
 
 /// The status of a Payer
 #[allow(missing_docs)] // undocumented by PayPal
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PayerStatus {
     Verified,
@@ -225,7 +225,7 @@ pub struct TransactionAmount {
 }
 
 /// Data about a credit card.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct FundingInstrument {
     /// Full representation of a credit card
     pub credit_card: Option<CreditCard>,
@@ -234,7 +234,7 @@ pub struct FundingInstrument {
 }
 
 /// A credit card
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CreditCard {
     /// The credit card number. Value is numeric characters only with no spaces or punctuation.
     /// Must conform to the modulo and length required by each credit card type. Redacted in
@@ -261,7 +261,7 @@ pub struct CreditCard {
 }
 
 /// Represents an address.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Address {
     /// The first line of the address. For example, number, street, and so on.
     pub line1: String,
@@ -288,7 +288,7 @@ pub struct Address {
 }
 
 /// The address normalization status. Returned only for payers from Brazil.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum NormalizationStatus {
     /// Unknown
@@ -302,7 +302,7 @@ pub enum NormalizationStatus {
 }
 
 /// A credit card in token representation.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CreditCardToken {
     /// The ID of credit card that is stored in the PayPal vault.
     pub credit_card_id: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,91 +1,325 @@
-#![allow(bad_style)]
-//
-// ResponseAccessToken {{{
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ResponseAccessToken
-{
+use chrono as chr;
+use serde::{Deserialize, Serialize};
+
+// paypals reply when requesting a new jwt
+#[derive(Deserialize, Debug)]
+pub struct ResponseAccessToken {
     scope: String,
     pub nonce: String,
     pub access_token: String,
     pub token_type: String,
     pub app_id: String,
     pub expires_in: i64,
-} //}}}
-  //RequestNewPayment {{{
-#[derive(Serialize, Deserialize, Debug)]
-pub struct RequestNewPayment
-{
+}
+
+#[derive(Serialize, Debug)]
+pub struct RequestNewPayment {
     pub intent: PaymentIntent,
     pub payer: Payer,
     pub transactions: Vec<Transaction>,
     pub redirect_urls: RedirectUrls,
-} //}}}
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ResponseNewPayment {
-    pub id:String,
-    pub intent:PaymentIntent,
-    pub payer:Payer,
-    pub state:State,
-    pub failure_reason:Failure_reason,
-    pub create_time:String,
-    pub update_time:String,
 }
+
+/// A single payment in PayPal's system, either completed or not.
+#[derive(Deserialize, Debug)]
+pub struct Payment {
+    /// The ID of the payment.
+    pub id: String,
+    /// The payment intent.
+    pub intent: PaymentIntent,
+    /// The source of the funds for this payment. Payment method is PayPal Wallet payment or bank
+    /// direct debit.
+    pub payer: Payer,
+    /// Use the application context resource to customize payment flow experience for your buyers.
+    pub application_context: Option<ApplicationContext>,
+    /// An array of payment-related transactions. A transaction defines what the payment is for and
+    /// who fulfills the payment. For update and execute payment calls, the transactions object
+    /// accepts the amount object only.
+    pub transactions: Vec<Transaction>,
+    /// The state of the payment.
+    pub state: Option<State>,
+    /// The PayPal-generated ID for the merchant's payment experience profile. For information, see
+    /// [create web experience profile](https://developer.paypal.com/docs/api/payment-experience/#web-profiles_create).
+    pub experience_profile_id: Option<String>,
+    /// A free-form field that clients can use to send a note to the payer.
+    pub note_to_payer: Option<String>,
+    /// A set of redirect URLs that you provide for PayPal-based payments.
+    pub redirect_urls: Option<RedirectUrls>,
+    /// The reason code for a payment failure.
+    pub failure_reason: Option<FailureReason>,
+    /// The date and time when the payment was created.
+    pub create_time: Option<chr::DateTime<chr::Utc>>,
+    /// The date and time when the payment was updated.
+    pub update_time: Option<chr::DateTime<chr::Utc>>,
+    /// An array of request-related
+    /// [HATEOAS links](https://developer.paypal.com/docs/api/reference/api-responses/#hateoas-links).
+    pub links: Vec<LinkDescription>,
+}
+
+/// Used to customize the payment flow page.
+#[derive(Deserialize, Debug)]
+pub struct ApplicationContext {
+    /// A label that overrides the business name in the merchant's PayPal account on the PayPal
+    /// checkout pages.
+    pub brand_name: Option<String>,
+    /// The locale of pages that the PayPal payment experience displays. A valid value is AU, AT,
+    /// BE, BR, CA, CH, CN, DE, ES, GB, FR, IT, NL, PL, PT, RU, or US. A five-character code is
+    /// also valid for languages in these countries: da_DK, he_IL, id_ID, ja_JP, no_NO, pt_BR,
+    /// ru_RU, sv_SE, th_TH, zh_CN, zh_HK, and zh_TW.
+    pub locale: String,
+    /// The type of landing page to show on the PayPal site for customer checkout. To use the
+    /// non-PayPal account landing page, set to Billing. To use the PayPal account log in landing
+    /// page, set to Login.
+    pub landing_page: String,
+    /// The shipping preference.
+    pub shipping_preference: ShippingPreference,
+    /// The user action.
+    pub user_action: String,
+}
+
+/// The shipping preference.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ShippingPreference {
+    /// Redacts the shipping address from the PayPal pages. Recommended for digital goods.
+    NoShipping,
+    /// Uses the customer-selected shipping address on PayPal pages.
+    GetFromFile,
+    /// If available, uses the merchant-provided shipping address, which the customer cannot change
+    /// on the PayPal pages. If the merchant does not provide an address, the customer can enter
+    /// the address on PayPal pages.
+    SetProvidedAddress,
+}
+
+/// A struct containing a url and some metadata.
+#[derive(Deserialize, Debug)]
+pub struct LinkDescription {
+    /// The complete target URL. To make the related call, combine the method with this URI
+    /// Template-formatted link. For pre-processing, include the `$`, `(`, and `)` characters. The
+    /// href is the key HATEOAS component that links a completed call with a subsequent call.
+    pub href: String,
+    /// The link relation type, which serves as an ID for a link that unambiguously describes the
+    /// semantics of the link.
+    pub rel: String,
+    /// The HTTP method required to make the related call.
+    /// Possible values: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `CONNECT`, `OPTIONS`, `PATCH`.
+    pub method: Option<String>,
+}
+
+/// Returned when listing all payments in the system.
+#[derive(Deserialize)]
+pub struct ListPaymentResponse {
+    /// A vector of the payments
+    pub payments: Vec<Payment>,
+    /// The number of payments, should be equal to `response.payments.len()`.
+    pub count: usize,
+    /// The ID of the element to use to get the next range of results.
+    pub next_id: Option<String>,
+}
+
+/// Represents the state of a payment.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum State {
-    created,
-    approved,
-    failed
+    /// The transaction was successfully created.
+    Created,
+    /// The customer approved the transaction. The state changes from created to approved on
+    /// generation of the sale_id for sale transactions, authorization_id for authorization
+    /// transactions, or order_id for order transactions.
+    Approved,
+    /// The transaction request failed.
+    Failed,
 }
+
+/// The reason code for a payment failure.
+#[allow(missing_docs)] // not documented by PayPal, but seems trivial
 #[derive(Serialize, Deserialize, Debug)]
-pub enum Failure_reason {
-    UNABLE_TO_COMPLETE_TRANSACTION,
-    INVALID_PAYMENT_METHOD,
-    PAYER_CANNOT_PAY,
-    CANNOT_PAY_THIS_PAYEE,
-    REDIRECT_REQUIRED,
-    PAYEE_FILTER_RESTRICTIONS
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FailureReason {
+    UnableToCompleteTransaction,
+    InvalidPaymentMethod,
+    PayerCannotPay,
+    CannotPayThisPayee,
+    RedirectRequired,
+    PayeeFilterRestrictions,
 }
+
+/// Struct containing urls where the users is redirected after visiting the paypal site.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct RedirectUrls
-{
+pub struct RedirectUrls {
+    /// The URL where the payer is redirected after he or she approves the payment.
+    /// *Required for PayPal account payments.*
     pub return_url: String,
+    /// The URL where the payer is redirected after he or she cancels the payment.
+    /// *Required for PayPal account payments.*
     pub cancel_url: String,
 }
-// intent{{{
+
+/// The type of payment that is created
 #[derive(Serialize, Deserialize, Debug)]
-pub enum PaymentIntent
-{
-    sale,
-    authorize,
-    order,
-} //}}}
-  // payer struct {{{
+#[serde(rename_all = "snake_case")]
+pub enum PaymentIntent {
+    /// Makes an immediate payment.
+    Sale,
+    /// Authorizes a payment for capture later.
+    Authorize,
+    /// Creates an order.
+    Order,
+}
+
+/// A paypal account that can be charged.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Payer
-{
+pub struct Payer {
+    /// The payment method.
     pub payment_method: PaymentMethod,
-} //}}}
-  // PaymentMethod struct {{{
+    /// The status of payer's PayPal account
+    pub status: Option<PayerStatus>,
+    /// An array of a single funding instrument for the current payment. Valid only and required
+    /// for the credit card payment method. The array must include either a credit_card or
+    /// credit_card_token object. If the array contains more than one instrument, the payment is
+    /// declined.
+    pub funding_instruments: Option<Vec<FundingInstrument>>,
+}
+
+/// Represents one of the ways paypal is able to process payments.
 #[derive(Serialize, Deserialize, Debug)]
-pub enum PaymentMethod
-{
-    credit_card,
-    paypal,
-    pay_upon_invoice,
-    carrier,
-    alternate_payment,
-    bank,
-} //}}}
-  // Transaction struct {{{
+#[serde(rename_all = "snake_case")]
+pub enum PaymentMethod {
+    /// Credit card.
+    CreditCard,
+    /// A PayPal Wallet payment.
+    Paypal,
+    /// Pay upon invoice.
+    PayUponInvoice,
+    /// Carrier.
+    Carrier,
+    /// Alternate payment.
+    AlternatePayment,
+    /// Bank.
+    Bank,
+}
+
+/// The status of a Payer
+#[allow(missing_docs)] // undocumented by PayPal
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PayerStatus {
+    Verified,
+    Unverified,
+}
+
+/// A single transaction in paypals system. A payment consists of zero or more transactions
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Transaction
-{
+pub struct Transaction {
+    /// The amount that is charged when this transaction is completed
     pub amount: TransactionAmount,
-} //}}}
-  // TransactionAmount struct{{{
+}
+
+/// A currency-aware representation of an amount of money
 #[derive(Serialize, Deserialize, Debug)]
-pub struct TransactionAmount
-{
+pub struct TransactionAmount {
+    /// The ISO 4217 currency code, for example "USD" or "EUR"
     pub currency: String,
+    /// The amount of currency that is to be charge, for example "10" or "12.34"
     pub total: String,
-} //}}}
+}
+
+/// Data about a credit card.
+#[derive(Deserialize)]
+pub struct FundingInstrument {
+    /// Full representation of a credit card
+    pub credit_card: Option<CreditCard>,
+    /// Token representation of a credit card
+    pub credit_card_token: Option<CreditCardToken>,
+}
+
+/// A credit card
+#[derive(Deserialize)]
+pub struct CreditCard {
+    /// The credit card number. Value is numeric characters only with no spaces or punctuation.
+    /// Must conform to the modulo and length required by each credit card type. Redacted in
+    /// responses.
+    pub number: String,
+    /// The credit card type. Value is visa, mastercard, discover, or amex. Do not use these
+    /// lowercase values for display.
+    #[serde(rename = "type")]
+    pub _type: String,
+    /// The expiration month with no leading zero. Value is from 1 to 12.
+    pub expire_month: i32,
+    /// The four-digit expiration year.
+    pub expire_year: i32,
+    /// The three- to four-digit card validation code.
+    pub cvv2: Option<String>,
+    /// The card holder's first name.
+    pub first_name: Option<String>,
+    /// The card holder's last name.
+    pub last_name: Option<String>,
+    /// The billing address for this card.
+    pub billing_address: Option<Address>,
+    /// An array of request-related HATEOAS links.
+    pub links: Vec<LinkDescription>,
+}
+
+/// Represents an address.
+#[derive(Deserialize)]
+pub struct Address {
+    /// The first line of the address. For example, number, street, and so on.
+    pub line1: String,
+    /// The second line of the address. For example, suite or apartment number.
+    pub line2: Option<String>,
+    /// The city name.
+    pub city: Option<String>,
+    /// The two-character ISO 3166-1 code that identifies the country or region.
+    pub country_code: String,
+    /// The postal code, which is the zip code or equivalent. Typically required for countries with
+    /// a postal code or an equivalent.
+    pub postal_code: Option<String>,
+    /// The code for a US state or the equivalent for other countries. Required for transactions if
+    /// the address is in one of these countries: Argentina, Brazil, Canada, China, India, Italy,
+    /// Japan, Mexico, Thailand, or United States. Maximum length is 40 single-byte characters.
+    pub state: Option<String>,
+    /// The phone number, in E.123 format. Maximum length is 50 characters.
+    pub phone: Option<String>,
+    /// The address normalization status.
+    pub normalization_status: Option<NormalizationStatus>,
+    /// The type of address. For example, HOME_OR_WORK, GIFT, and so on.
+    #[serde(rename = "type")]
+    pub _type: Option<String>,
+}
+
+/// The address normalization status. Returned only for payers from Brazil.
+#[derive(Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum NormalizationStatus {
+    /// Unknown
+    Unknown,
+    /// Unnormalized user preferred.
+    UnnormalizedUserPreferred,
+    /// Normalized.
+    Normalized,
+    /// Unnormalized.
+    Unnormalized,
+}
+
+/// A credit card in token representation.
+#[derive(Deserialize)]
+pub struct CreditCardToken {
+    /// The ID of credit card that is stored in the PayPal vault.
+    pub credit_card_id: String,
+    /// A unique ID that you can assign and track when you store a credit card in the vault or use
+    /// a vaulted credit card. This ID can help to avoid unintentional use or misuse of credit
+    /// cards and can be any value, such as a UUID, user name, or email address. *Required* when
+    /// you use a vaulted credit card and if a payer_id was originally provided when you vaulted
+    /// the credit card.
+    pub payer_id: Option<String>,
+    /// The last four digits of the stored credit card number.
+    pub last4: Option<String>,
+    /// The credit card type. Value is visa, mastercard, discover, or amex. Do not use these
+    /// lowercase values for display.
+    #[serde(rename = "type")]
+    pub _type: Option<String>,
+    /// The expiration month with no leading zero. Value is from 1 to 12.
+    pub expire_month: Option<i32>,
+    /// The four-digit expiration year.
+    pub expire_year: Option<i32>,
+}


### PR DESCRIPTION
Hi!

First off, thank you for providing an open source crate to talk to the PayPal API. Sorely needed in one of my projects.

Since I am using this project I decided to contribute to it as well. I created a fork that now has a couple of changes:

- I used the serde macros to no longer require the `#[allow(bad_style)]` annotation in the types file
- I used reqwest's provided `.json()` method to enable easier deserializing.
- Rather than providing the response body as a string, I created several types to which the response is deserialized in the case of a successful response.
- In the case of a 2xx or 3xx response, the methods no longer return an `Ok`, but instead use the `Err` variant.
- I added documentation to all public enums, structs and functions.
- I added several unit tests, though not everything is covered.
- I added an Error type to the crate.

I hope this is a welcome addition to your project!